### PR TITLE
[FEAT!] individualCalendar에서 재로그인한 사용자의 스케줄 로딩 로직 수정

### DIFF
--- a/src/components/TimePicker.css
+++ b/src/components/TimePicker.css
@@ -4,17 +4,21 @@
   align-items: center;
   margin-top: 20px;
   padding: 20px;
+  /* height: 800px; */
 }
-.modal-overlay {
-  touch-action: none; /* 모바일에서 스크롤 방지 */
-  -webkit-tap-highlight-color: transparent; /* 탭 하이라이트 제거 */
+/* .modal-overlay {
+  touch-action: none; 
+  -webkit-tap-highlight-color: transparent; 
 }
 
 .modal-content {
-  touch-action: pan-y; /* 모달 내부는 세로 스크롤 허용 */
-  -webkit-overflow-scrolling: touch; /* iOS에서 부드러운 스크롤 */
+  touch-action: pan-y; 
+  -webkit-overflow-scrolling: touch; 
+} */
+.time-section {
+  width: 100%;
+  margin-bottom: 16px;
 }
-
 
 .time-option.disabled {
   opacity: 0.5;
@@ -22,14 +26,10 @@
   color: #ccc;
 }
 .time-label {
-  color: #444444;
-  font-family: "Pretendard-Medium", Helvetica;
-  font-size: 14px;
-  font-weight: 500;
-  margin-left: 0;
-  margin-bottom: 10px;
-  text-align: left;
-  width: 100%;
+
+  display: flex;
+  flex-direction: row;
+
 }
 
 .time-range {
@@ -38,9 +38,11 @@
   background-color: #ffffff;
   border: 1px solid #f2f2f2;
   border-radius: 6px;
-  height: 48px;
+  height: auto;
   padding: 0 27px;
   gap: 10px;
+  flex-direction: column;
+
 }
 
 .time-range.disabled {
@@ -58,6 +60,13 @@
 }
 
 .time-button {
+  background-color: white;
+  border: none;
+  padding: 14px 21px;
+  font-size: 16px;
+  cursor: pointer;
+}
+.time-title {
   background-color: white;
   border: none;
   padding: 14px 21px;
@@ -192,15 +201,25 @@ input:checked + .slider:before {
   margin: 30px auto;
 }
 
-.hour-select,
-.minute-select {
-  max-height: 200px; /* 필요에 따라 높이 조정 */
+.hour-select{
+  max-height: 160px; /* 필요에 따라 높이 조정 */
   overflow-y: auto; /* 스크롤 가능하게 변경 */
   margin: 0 10px;
   display: flex;
   flex-direction: column;
   align-items: center;
+  width:200px;
 }
+
+.time-options {
+  display: flex;
+  flex-direction: column;
+  max-height: 150px; /* 3개만 표시 */
+  overflow-y: auto; /* 초과 숨김 */
+  padding: 8px;
+}
+
+
 
 .time-option {
   padding: 19px 25px;
@@ -217,7 +236,7 @@ input:checked + .slider:before {
 }
 
 .time-option.selected {
-  color: black;
+  color: blue;
 }
 
 .time-option:hover {
@@ -232,7 +251,8 @@ input:checked + .slider:before {
 
 /* 스크롤바 숨기기 (필요 시) */
 .hour-select::-webkit-scrollbar,
-.minute-select::-webkit-scrollbar {
+.minute-select::-webkit-scrollbar
+.time-option::-webkit-scrollbar {
   width: 0;
   background: transparent;
 }

--- a/src/components/TimePicker.js
+++ b/src/components/TimePicker.js
@@ -1,229 +1,158 @@
 import React, { useState } from 'react';
 import './TimePicker.css';
-import { useNavigate } from 'react-router-dom';
 
-const TimePicker = ({ jsonData, startTime, endTime, setStartTime, setEndTime, onCreateCalendar }) => {
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isSelectingStartTime, setIsSelectingStartTime] = useState(false);
-  const [isAllDay, setIsAllDay] = useState(false);
-  const navigate = useNavigate();
+const TimePicker = ({ startTime, endTime, setStartTime, setEndTime }) => {
+  const [isStartOpen, setIsStartOpen] = useState(false);
+  const [isEndOpen, setIsEndOpen] = useState(false);
   const [touchStart, setTouchStart] = useState(null);
 
-  // 시간을 분으로 변환하는 유틸리티 함수
+  // 아코디언 토글 함수
+  const toggleStartAccordion = () => {
+    setIsStartOpen((prev) => !prev);
+    setIsEndOpen(false); 
+  };
+
+  const toggleEndAccordion = () => {
+    setIsEndOpen((prev) => !prev);
+    setIsStartOpen(false); 
+  };
   const timeToMinutes = (time) => {
     if (!time) return 0;
     const [hours, minutes] = time.split(':').map(Number);
     return hours * 60 + minutes;
   };
-
-  // 선택 가능한 시간 범위를 결정하는 함수
-  const isTimeSelectable = (hour, minute, isStart) => {
+  
+  // 기존 로직 유지: 선택 가능한 시간 범위 확인
+  const isTimeSelectable = (hour, minute, isStart, startTime, endTime) => {
     const currentTime = hour * 60 + minute;
-    
+  
     if (isStart) {
-      // startTime을 선택할 때는 endTime보다 이전이어야 함
+       // startTime을 선택할 때는 endTime보다 이전이어야 함
       return endTime ? currentTime < timeToMinutes(endTime) : true;
     } else {
-      // endTime을 선택할 때는 startTime보다 이후여야 함
-      return startTime ? currentTime > timeToMinutes(startTime) : true;
+        // endTime을 선택할 때는 startTime보다 이후여야 함
+        return startTime ? currentTime > timeToMinutes(startTime) : true;
     }
   };
 
-  const handleTimeClick = (isStart) => {
-    setIsSelectingStartTime(isStart);
-    setIsModalOpen(true);
+  
+  // 시간 선택 처리 함수
+  const handleTimeSelect = (hour, isStart) => {
+    const formattedTime = `${hour < 10 ? `0${hour}` : hour}:00`;
+
+    if (isStart) {
+      // 선택하려는 시간이 유효한지 확인
+      if (!isTimeSelectable(hour, 0, true, startTime, endTime)) return; // 유효하지 않은 선택은 무시
+      setStartTime(formattedTime); 
+    } else {
+      // 선택하려는 시간이 유효한지 확인
+      if (!isTimeSelectable(hour, 0, false, startTime, endTime)) return; // 유효하지 않은 선택은 무시
+      setEndTime(formattedTime);
+    }
+
+    // 선택 후 아코디언 닫기
+    if (isStart) {
+      setIsStartOpen(false);
+    } else {
+      setIsEndOpen(false);
+    }
+  };
+
+  // 선택 가능한 시간 옵션을 생성하는 함수
+  const renderTimeOptions = (isStart) => {
+    return Array.from({ length: 24 }, (_, i) => (
+      <div
+        key={i}
+        className={`time-option ${
+          !isTimeSelectable(i, 0, isStart, startTime, endTime) ? 'disabled' : ''
+        }`}
+        onClick={() => isTimeSelectable(i, 0, isStart, startTime, endTime) && handleTimeSelect(i, isStart)}
+      >
+        {/* {i < 12 ? `오전 ${i === 0 ? 12 : i}` : `오후 ${i > 12 ? i - 12 : i}`} */}
+     
+        {i < 12 ? ` ${i === 0 ? 12 : i}` : ` ${i > 12 ? i - 12 : i}`}
+
+      </div>
+    ));
   };
 
   const handleModalClose = () => {
-    setIsModalOpen(false);
+    setIsStartOpen(false);
+    setIsEndOpen(false);
   };
+
   // 터치 이벤트 핸들러 추가
   const handleTouchStart = (e) => {
-    // 모달 컨텐츠 영역을 터치한 경우는 무시
+        // 모달 컨텐츠 영역을 터치한 경우는 무시
     if (e.target.closest('.modal-content')) return;
-    
-    // 터치 시작 위치 저장
+
     setTouchStart({
       x: e.touches[0].clientX,
-      y: e.touches[0].clientY
+      y: e.touches[0].clientY,
     });
   };
 
+  
+  // 터치 종료 위치 계산
   const handleTouchEnd = (e) => {
-    // 모달 컨텐츠 영역을 터치한 경우는 무시
     if (e.target.closest('.modal-content')) return;
 
-    // 터치 종료 위치 계산
     const touchEnd = {
       x: e.changedTouches[0].clientX,
-      y: e.changedTouches[0].clientY
+      y: e.changedTouches[0].clientY,
     };
 
     // 터치 시작점이 있고, 이동 거리가 작은 경우(탭으로 간주)에만 모달 닫기
     if (touchStart) {
       const deltaX = Math.abs(touchEnd.x - touchStart.x);
       const deltaY = Math.abs(touchEnd.y - touchStart.y);
-      
+
       // 10픽셀 이내의 이동은 탭으로 간주
       if (deltaX < 10 && deltaY < 10) {
         handleModalClose();
       }
     }
-    
     // 터치 시작점 초기화
     setTouchStart(null);
   };
-  const handleTimeSelect = (value, type) => {
-    const formattedValue = value;
-
-    if (type === 'hour') {
-      const currentMinutes = isSelectingStartTime ? 
-        (startTime ? startTime.split(':')[1] : '00') : 
-        (endTime ? endTime.split(':')[1] : '00');
-
-      // 선택하려는 시간이 유효한지 확인
-      if (!isTimeSelectable(parseInt(value), parseInt(currentMinutes), isSelectingStartTime)) {
-        return; // 유효하지 않은 선택은 무시
-      }
-
-      if (isSelectingStartTime) {
-        setStartTime((prev) => {
-          const [prevHour, prevMinute] = (prev || "00:00").split(':');
-          return `${formattedValue}:${prevMinute}`;
-        });
-      } else {
-        setEndTime((prev) => {
-          const [prevHour, prevMinute] = (prev || "00:00").split(':');
-          return `${formattedValue}:${prevMinute}`;
-        });
-      }
-    } else if (type === 'minute') {
-      const currentHour = isSelectingStartTime ?
-        (startTime ? startTime.split(':')[0] : '00') :
-        (endTime ? endTime.split(':')[0] : '00');
-
-      // 선택하려는 분이 유효한지 확인
-      if (!isTimeSelectable(parseInt(currentHour), parseInt(value), isSelectingStartTime)) {
-        return; // 유효하지 않은 선택은 무시
-      }
-
-      if (isSelectingStartTime) {
-        setStartTime((prev) => {
-          const [prevHour, prevMinute] = (prev || "00:00").split(':');
-          return `${prevHour}:${formattedValue}`;
-        });
-      } else {
-        setEndTime((prev) => {
-          const [prevHour, prevMinute] = (prev || "00:00").split(':');
-          return `${prevHour}:${formattedValue}`;
-        });
-      }
-    }
-    setIsModalOpen(false);
-  };
-
-  const handleAllDayToggle = () => {
-    setIsAllDay(!isAllDay);
-  };
-
-  // 선택 가능한 시간 옵션을 생성하는 함수
-  const renderTimeOptions = (type) => {
-    const options = type === 'hour' 
-      ? Array.from({ length: 24 }, (_, i) => i)
-      : Array.from({ length: 6 }, (_, i) => i * 10);
-    
-    return options.map(value => {
-      const formattedValue = value < 10 ? `0${value}` : `${value}`;
-      const isSelectable = isTimeSelectable(
-        type === 'hour' ? value : parseInt(isSelectingStartTime ? startTime?.split(':')[0] : endTime?.split(':')[0]),
-        type === 'minute' ? value : parseInt(isSelectingStartTime ? startTime?.split(':')[1] : endTime?.split(':')[1]),
-        isSelectingStartTime
-      );
-
-      return (
-        <div
-          key={`${type}-${value}`}
-          className={`time-option ${!isSelectable ? 'disabled' : ''}`}
-          onClick={() => isSelectable && handleTimeSelect(formattedValue, type)}
-        >
-          {formattedValue}
-        </div>
-      );
-    });
-  };
 
   return (
-    <div className="time-picker-container" disabled={isAllDay}>
-      <div className="time-label">시간대 표시</div>
-
-      <div className={`time-range ${isAllDay ? 'disabled' : ''}`}>
-        <button className="time-button" onClick={() => handleTimeClick(true)} disabled={isAllDay}>
-          {startTime}
-        </button>
-        <div className="time-separator"></div>
-        <button className="time-button" onClick={() => handleTimeClick(false)} disabled={isAllDay}>
-          {endTime}
-        </button>
-      </div>
-
-      <div className="all-day-toggle">
-        <label className="switch">
-          <input type="checkbox" checked={isAllDay} onChange={handleAllDayToggle} />
-          <span className="slider"></span>
-        </label>
-        <label>하루 종일</label>
-      </div>
-
-      <button className="create-calendar-button" onClick={onCreateCalendar}>
-        이벤트 캘린더 만들기
-      </button>
-
-      {isModalOpen && (
-        <div 
-          className="modal-overlay"
-          onClick={handleModalClose}
-          onTouchStart={handleTouchStart}
-          onTouchEnd={handleTouchEnd}
-        >
-          <div 
-            className="modal-content" 
-            onClick={(e) => e.stopPropagation()}
-            onTouchStart={(e) => e.stopPropagation()}
-            onTouchEnd={(e) => e.stopPropagation()}
-          >
-            <div className="time-select-container">
-              <div className="hour-select">
-                {renderTimeOptions('hour')}
-              </div>
-              <div className="time-separator2">:</div>
-              <div className="minute-select">
-                {renderTimeOptions('minute')}
-              </div>
-            </div>
-          </div>
+    <div className="time-picker-container">
+      {/* 시작 시간 */}
+      <div className="time-section">
+        <div className="time-label" onClick={toggleStartAccordion}>
+          <span>시작 시간    </span>
+          <span>{startTime}</span>
         </div>
-      )}
+        {isStartOpen && (
+          <div
+            className="time-options"
+            onTouchStart={handleTouchStart}
+            onTouchEnd={handleTouchEnd}
+          >
+            {renderTimeOptions(true)}
+          </div>
+        )}
+      </div>
+
+      {/* 종료 시간 */}
+      <div className="time-section">
+        <div className="time-label" onClick={toggleEndAccordion}>
+          <span>종료 시간   </span>
+          <span>{endTime}</span>
+        </div>
+        {isEndOpen && (
+        <div
+         className="time-options"
+         onTouchStart={handleTouchStart}
+         onTouchEnd={handleTouchEnd}>
+          {renderTimeOptions(false)}
+          </div>
+        )}
+      </div>
     </div>
   );
 };
-{/* 
-      {isModalOpen && (
-        <div className="modal-overlay" onClick={handleModalClose}>
-          <div className="modal-content" onClick={(e) => e.stopPropagation()}>
-            <div className="time-select-container">
-              <div className="hour-select">
-                {renderTimeOptions('hour')}
-              </div>
-              <div className="time-separator2">:</div>
-              <div className="minute-select">
-                {renderTimeOptions('minute')}
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}; */}
+
 
 export default TimePicker;

--- a/src/pages/MonthView.js
+++ b/src/pages/MonthView.js
@@ -92,6 +92,7 @@ import MyPage from './MyPage';
     }
   // }, [selectedDates, eventName, setJsonData]);
 }, [selectedDates, eventName, startTime, endTime, setJsonData]);
+
 // 
 
   const handleInputChange = (e) => {

--- a/src/pages/individualCalendar.js
+++ b/src/pages/individualCalendar.js
@@ -11,10 +11,10 @@ const IndividualCalendar = () => {
   
     // const { responseData, appointmentId, userSchedule } = location.state;
 
-  console.log("받은 전체 responseData 구조:", responseData);
-  console.log("responseData.object 구조:", responseData.object);
-   console.log("user 스케줄정보: ", responseData.userSchedule);
-  console.log("user이름:",userName );
+  // console.log("받은 전체 responseData 구조:", responseData);
+  // console.log("responseData.object 구조:", responseData.object);
+  //  console.log("user 스케줄정보: ", responseData.userSchedule);
+  // console.log("user이름:",userName );
 
 
   const [dates, setDates] = useState([]);
@@ -24,11 +24,11 @@ const IndividualCalendar = () => {
   const [selectedTimes, setSelectedTimes] = useState({});
   const navigate = useNavigate(); 
 
-  console.log("appointmentId는 이것: ", appointmentId); //정상작동
+  // console.log("appointmentId는 이것: ", appointmentId); //정상작동
 
   useEffect(() => {
 
-    //step1. appointment 전체의 스케줄 틀 불러옴옴
+    //step1. appointment 전체의 스케줄 틀 불러옴
     if (responseData) {
       setEventName(responseData.object.name);
       moment.locale('ko');
@@ -39,9 +39,9 @@ const IndividualCalendar = () => {
       // [responseData.object];
       const schedules = responseData.object.schedules;
 
-      console.log("schedules의 타입:", typeof schedules);
-      console.log("schedules는는 배열?:", Array.isArray(schedules));
-      console.log("schedules의 내용", schedules);
+      // console.log("schedules의 타입:", typeof schedules);
+      // console.log("schedules는는 배열?:", Array.isArray(schedules));
+      // console.log("schedules의 내용", schedules);
       //빈 스케줄 받았을 때 에외처리
       if(!schedules){
         console.error('schedules 비어있음');
@@ -49,7 +49,7 @@ const IndividualCalendar = () => {
       }
   
 
-      console.log("이거슨 사용자의 스케줄", schedules);
+      // console.log("이거슨 appointment자체의 스케줄", schedules);
 
 
       // 날짜 및 시간 데이터 설정
@@ -57,9 +57,9 @@ const IndividualCalendar = () => {
       const datesArray = schedules.map((schedule, index) => {
         const dateString = schedule.date;
         const date = moment.utc(dateString).format('YYYY-MM-DD');
-        console.log("이거슨 date:", date);
-        console.log("이거슨 key:", index);
-        console.log("이거슨 id:", schedule.id);
+        // console.log("이거슨 date:", date);
+        // console.log("이거슨 key:", index);
+        // console.log("이거슨 id:", schedule.id);
 
         return { date, key: index, id: schedule.id };
       });
@@ -94,30 +94,124 @@ const IndividualCalendar = () => {
       setDates(datesArray);
       setTimes(timesFormatted);
 
+      console.log("기본 날짜 상태 datesArray: ", datesArray); //ex "2025-01-02"
+      console.log("기본 timesFormatted: ", timesFormatted); //ex "09:00"
 
-    //step2. 사용자가 이전에 저장된 선택된 시간 불러옴옴
-      if (responseData.firstLogin === false && responseData.object.times) {
-        const savedTimes = {};
-        responseData.object.times.forEach(timeSlot => {
-          const dateIndex = datesArray.findIndex(dateObj => dateObj.date === moment.utc(timeSlot.date).format('YYYY-MM-DD'));
-          if (dateIndex !== -1) {
-            savedTimes[dateIndex] = savedTimes[dateIndex] || {};
-            timeSlot.times.forEach((time, index) => {
-              const timeIndex = timesFormatted.indexOf(moment(time.time).format('HH시'));
-              if (timeIndex !== -1) {
-                savedTimes[dateIndex][timeIndex] = {
-                  ...savedTimes[dateIndex][timeIndex],
-                  [index]: true,
-                };
-              }
-            });
-          }
+    // console.log("사용자가 저장했던 times?: ", responseData.userSchedule[0].times);
+
+    //step2. 사용자가 이전에 저장된 선택된 시간 불러옴
+      // if (responseData.firstLogin === false && responseData.userSchedule[0].times) {
+      console.log("첫로그인???: ",responseData.firstLogin);
+
+      if (responseData.firstLogin === false) {
+        console.log("사용자가 저장했던 times?: ", responseData.userSchedule[0].times);
+
+        const userSelections = responseData.userSchedule[0].times.reduce((acc, slot) => {
+          const slotDate = moment.utc(slot.time).format('YYYY-MM-DD');
+          const slotHour = moment.utc(slot.time).format('HH');
+          const slotMinute = moment.utc(slot.time).format('mm');
+          
+          console.log("처리중인 slot:", {
+            originalTime: slot.time,
+            slotDate,
+            slotHour,
+            slotMinute
         });
-        setSelectedTimes(savedTimes);
-      }
-    }
-  }, [responseData]);
 
+          if (!acc[slotDate]) acc[slotDate] = {};
+          if (!acc[slotDate][slotHour]) acc[slotDate][slotHour] = [];
+          
+          acc[slotDate][slotHour].push(parseInt(slotMinute));
+          return acc;
+      }, {});
+      
+      console.log("정리된 사용자 선택:", userSelections);
+        const savedTimes = {};
+        
+        // datesArray를 기준으로 순회
+        // datesArray.forEach((dateInfo, dateIndex) => {
+        //     // timesFormatted를 기준으로 순회
+        //     console.log("dateInfo: ", dateInfo);
+        //     console.log("dateIndex: ", dateIndex);
+
+        //     timesFormatted.forEach((time) => {
+        //         const hour = moment(time, 'HH:mm').format('HH');
+        //         // 해당 날짜에 해당 시간대에 사용자가 선택한 시간이 있는지 확인
+        //         const selectedTimeSlots = responseData.userSchedule[0].times.filter(slot => {
+        //             const slotDate = moment.utc(slot.time).format('YYYY-MM-DD');
+        //             const slotHour = moment.utc(slot.time).format('HH');
+        //             console.log("웨않되????", slotDate);
+        //             console.log("웨않되", slotHour);
+        //             console.log("ㅠㅠ", hour);
+        //             return slotDate === dateInfo.date && slotHour === hour;
+        //         });
+        //         console.log("selectedTimeSlots: ", selectedTimeSlots);
+
+        //         // 선택된 시간이 있다면 처리
+        //         if (selectedTimeSlots.length > 0) {
+        //             selectedTimeSlots.forEach(slot => {
+        //                 const minutes = parseInt(moment.utc(slot.time).format('mm'));
+        //                 const buttonIndex = minutes / 10;
+
+        //                 if (!savedTimes[dateIndex]) {
+        //                     savedTimes[dateIndex] = {};
+        //                 }
+        //                 // if (!savedTimes[dateIndex][timeIndex]) {
+        //                 //     savedTimes[dateIndex][timeIndex] = {};
+        //                 // }
+                        
+        //                 // savedTimes[dateIndex][timeIndex][buttonIndex] = true;
+        //             });
+        //         }
+        //     });
+        // });
+        datesArray.forEach((dateInfo, dateIndex) => {
+          const datePath = dateInfo.date;
+          console.log("처리중인 날짜:", {
+            datePath,
+            existingSelections: userSelections[datePath]
+        });
+          if (userSelections[datePath]) {
+              if (!savedTimes[dateIndex]) savedTimes[dateIndex] = {};
+              
+              timesFormatted.forEach((time, timeIndex) => {
+                const hour = moment(time, 'HH:mm').format('HH'); // 시간만 추출해서 비교
+
+                console.log("비교중:", {
+                  time,
+                  availableSelections: userSelections[datePath][hour]
+              });
+                  const minutes = userSelections[datePath][hour];
+                  if (minutes) {
+                      savedTimes[dateIndex][timeIndex] = {};
+                      minutes.forEach(minute => {
+                          const buttonIndex = minute / 10;
+                          savedTimes[dateIndex][timeIndex][buttonIndex] = true;
+                          console.log("저장완료:", {
+                            dateIndex,
+                            timeIndex,
+                            buttonIndex,
+                            savedTimes
+                        });
+                      });
+                  }
+              });
+          }
+      });
+        console.log("역순으로 처리된 savedTimes:", savedTimes);
+        setSelectedTimes(savedTimes);
+    }
+ } 
+}, [responseData]);
+
+
+useEffect(() => {
+  if (selectedTimes) {
+      console.log("selectedTimes가 업데이트됨:", selectedTimes);
+  }
+}, [selectedTimes]); 
+
+  
   // 저장 버튼 클릭 시 이동하는 함수
   const handleSaveClick = () => {
     // 필요한 로직 처리 후 페이지 이동
@@ -136,7 +230,7 @@ const IndividualCalendar = () => {
       [buttonIndex]: !isSelected,
     };
     setSelectedTimes(newSelectedTimes);
-    console.log('지금 선택한 buttonIndex:', buttonIndex);
+    // console.log('지금 선택한 buttonIndex:', buttonIndex);
 
     const selectedDateInfo = dates[selectedDate];
 
@@ -145,8 +239,8 @@ const IndividualCalendar = () => {
     const hour = times[timeIndex].split(':')[0];  // 시간만 추출 (예: "15")
     const minute = buttonIndex * 10;  // 분 계산 (예: 10)
     const dateTime = `${selectedDateInfo.date}T${hour}:${String(minute).padStart(2, '0')}:00`;
-    console.log('생성된 dateTime:', dateTime);
-    console.log('UTC 변환 후:', moment.utc(dateTime, "YYYY-MM-DDTHH:mm:ss").format("YYYY-MM-DDTHH:mm:ss"));
+    // console.log('생성된 dateTime:', dateTime);
+    // console.log('UTC 변환 후:', moment.utc(dateTime, "YYYY-MM-DDTHH:mm:ss").format("YYYY-MM-DDTHH:mm:ss"));
     const payload = {
       id: selectedDateInfo.id,
       date: moment.utc(dateTime, "YYYY-MM-DDTHH:mm:ss").format("YYYY-MM-DDTHH:mm:ss"),

--- a/src/pages/invite.js
+++ b/src/pages/invite.js
@@ -52,18 +52,20 @@ const Invite = () => {
  
           if (userScheduleResponse.ok) {
             const userScheduleData = await userScheduleResponse.json();
-            console.log('사용자 스케줄 데이터:', userScheduleData);
+            console.log('invite.js, 유저 개인 스케?줄정보:', userScheduleData);
+            
             const appointmentResponse = await fetch(
               `http://localhost:8080/api/v1/appointment/getAppointment?appointmentId=${appointmentId}`
             ); 
               if (appointmentResponse.ok) {
                 const appointmentData = await appointmentResponse.json();
-                
+                // console.log("저쪽 invite.js 신사 분이 보내주신 appointmentData입니다다: ", appointmentData);
+
                 //재로그인 case
                 if (userScheduleData.object && userScheduleData.object.length > 0) {
                   // responseData = userScheduleData;
                   // responseData.firstLogin = false;
-                  // console.log("재로그인이네?");
+                  console.log("재로그인이네?");
                   // console.log("응답데이터::: ", responseData);
                   // console.log("약속id:", appointmentId);
                   // console.log("재로그인한 사용자 이름", name);
@@ -72,11 +74,14 @@ const Invite = () => {
                     userSchedule: userScheduleData.object,
                     firstLogin: false
                   };
-                  console.log("재로그인시 responseData 구조:", {
+                  
+                  console.log("(((재로그인))))저쪽 invite.js 신사 분이 보내주신 재로그인시의 responseData 구조:", {
                     ...appointmentData,
                     userSchedule: userScheduleData.object,
                     firstLogin: false
                 });
+                // console.log("invite.js가 보낸 userSchedule: ", userScheduleData.object);
+
                 } else { //첫로그인 case
                   responseData = {
                     ...appointmentData,


### PR DESCRIPTION
- 서버 데이터에서 UI에 반영될 수 있게, 적절한 timeslot 매핑 추가
     - 기존의 사용자가 선택했던 시간대를 직접 순회하던 방식에서, 전체 date , 각 date의 각각의 
     시간대 순서대로 순회하며 사용자가 선택했던시간대가 있는지 check하는 로직으로 수정
     - 실제 UI에서 display할때 쓰던 데이터 형식으로 정확하게 변환되게 수정
     - hour 및 min 관련해서 상황에 맞게 포맷 적절히 변환되게 수정 


// footer
Resolves: [#6](https://github.com/TEAM-WHEN-WILL-WE-MEET/WWWM-REACT-FE/issues/6#issue-2766217477)
