### PR TITLE
[FIX] develop환경에서 BASE_URL이 https로 바뀌는 버그 해결

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -31,7 +31,6 @@
     <meta property="og:image" content="https://ifh.cc/g/ccKapj.jpg" />
     <meta name="color-scheme" content="light"/>
     <meta name="supported-color-schemes" content="light"/>
-    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
- #36 이슈를 해결하는 과정에서, 해당 이슈의 원인이 mixed content에 있는 것으로 파악하여 `<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">`을 추가했었음. 
- 이로 인해 해당 버그가 발생했고, #36 이슈의 원인은 결론적으로 mixed content에 있지않았기에 해당 코드 삭제하여 해당 버그를 fix함.

 
mixed content : 
이미지 URL이 HTTP로 되어 있으면, 페이지가 HTTPS로 로드되는 경우 브라우저나 소셜 미디어 플랫폼에서 mixed content 문제로 인해 이미지를 제대로 불러오지 못