### PR TITLE
[UPDATE] HelmetProvider 누락 다시 복구

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,12 +3,15 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { HelmetProvider } from 'react-helmet-async';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+  <HelmetProvider>
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  </HelmetProvider>
 );
 
 reportWebVitals();


### PR DESCRIPTION
- 하위 페이지에서 Helmet 태그를 사용하고자, 상위 페이지에 HelmetProvider 추가