### PR TITLE
[FIX!] firebase에 pre-render 기능 추가

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -8,6 +8,26 @@
     ],
     "rewrites": [
       {
+        "source": "/",
+        "destination": "/index.html"
+      },
+      {
+        "source": "/MonthView",
+        "destination": "/MonthView/index.html"
+      },
+      {
+        "source": "/invite",
+        "destination": "/invite/index.html"
+      },
+      {
+        "source": "/individualCalendar",
+        "destination": "/individualCalendar/index.html"
+      },
+      {
+        "source": "/eventCalendar",
+        "destination": "/eventCalendar/index.html"
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }

--- a/hydratable.config.json
+++ b/hydratable.config.json
@@ -1,5 +1,5 @@
 {
-  "crawlingUrls": ["/", "/MonthView", "/invite", "/eventCalendar"],
+  "crawlingUrls": ["/", "/MonthView", "/individualCalendar","/invite", "/eventCalendar"],
   "delay": 1500,
   "pageCount": 1,
   "retryCount": 1


### PR DESCRIPTION
- 로컬에서 npm run build했을 때는 각 페이지의 독자적인 메타태그가 들어가는 것을 확인했음. 
- 그러나 https환경에서 배포된 사이트 개발자도구 및 postman에 url 입력시 메타 태그가 제대로 적용되지 않는 버그가 있었음.
- 이에, firebase의 SPA 전용 세팅(rewrite - index.html) 을 수정하여, 요청이 있을 경우 각 페이지 별 메타태그가 들어가게 수정함.
- hydratable.config.json의 누락된 individualCalendar 추가