### PR TITLE
[FIX] Production 환경에서 카카오 공유하기 및 링크 공유 기능 문제

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -16,10 +16,6 @@
         "destination": "/MonthView/index.html"
       },
       {
-        "source": "/invite",
-        "destination": "/invite/index.html"
-      },
-      {
         "source": "/individualCalendar",
         "destination": "/individualCalendar/index.html"
       },

--- a/hydratable.config.json
+++ b/hydratable.config.json
@@ -1,5 +1,5 @@
 {
-  "crawlingUrls": ["/", "/MonthView", "/individualCalendar","/invite", "/eventCalendar"],
+  "crawlingUrls": ["/", "/MonthView", "/individualCalendar", "/eventCalendar"],
   "delay": 1500,
   "pageCount": 1,
   "retryCount": 1


### PR DESCRIPTION
- SEO 최적화를 위해, 각 path로 접근 시, 각 페이지별 소개가 적힌 메타 태그가 적용된 각각의 index.html를 만들어 severing했음. 
  - 즉,해당부분만  React 고유의 동작인 SPA가 아닌 SSR처럼 동작할 수 있게 의도함. 
- 그런데 invite.js 페이지의 경우 약속마다 UUID가 다름. 즉 약속마다 `/invite?appointmentId=UUID`로 동적으로 접근이 되어야하는데, 정적 라우팅 형식으로 접근시키다보니 오류가 난 것으로 추정되어, 해당 부분을 FIX함.

//footer
(진짜 https환경에서도 해결됐는지 확인 후 올릴 예정)