### PR TITLE
[FIX] 새로고침시 404페이지 뜨는 버그 fix

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -16,12 +16,8 @@
         "destination": "/MonthView/index.html"
       },
       {
-        "source": "/individualCalendar",
-        "destination": "/individualCalendar/index.html"
-      },
-      {
-        "source": "/eventCalendar",
-        "destination": "/eventCalendar/index.html"
+        "source": "/invite",
+        "destination": "/invite/index.html"
       },
       {
         "source": "**",

--- a/hydratable.config.json
+++ b/hydratable.config.json
@@ -1,5 +1,5 @@
 {
-  "crawlingUrls": ["/", "/MonthView", "/individualCalendar", "/eventCalendar"],
+  "crawlingUrls": ["/", "/MonthView", "/invite"],
   "delay": 1500,
   "pageCount": 1,
   "retryCount": 1

--- a/src/pages/MonthView.js
+++ b/src/pages/MonthView.js
@@ -299,12 +299,12 @@ const inputClasses = twMerge(
           // onClick={() => navigate('/mypage')} 
           onClick={() => navigate('/')}  
         />
-        <img 
+        {/* <img 
           alt=""
           src="/hambugerMenu.svg" 
           className="cursor-pointer p-[1.2rem] "
           onClick={() => navigate('/menu')} 
-        />
+        /> */}
       </div>
       <div className="relative px-4">
         <input

--- a/src/pages/eventCalendar.js
+++ b/src/pages/eventCalendar.js
@@ -80,7 +80,7 @@ const handleShare = () => {
     setIsOpen(false);
   };
   // Share 공유 ( 클립보드 복사)
-const shareString = `https://when-will-we-meet.site/invite?appointmentId=${appointmentId}`;
+const shareString = `https://when-will-we-meet.com/invite?appointmentId=${appointmentId}`;
 const clipboardShare = async() =>{
   try{
     await navigator.clipboard.writeText(shareString);


### PR DESCRIPTION
  - 로그인 후 접근 가능한 /individualCalendar, /eventCalendar는 hydratable이 사전 렌더링 시 invite 페이지에서 막혀 크롤링에 실패함.
  - 이로 인해 해당 경로의 index.html이 생성되지 않거나 내용이 비어, Firebase에서 rewrite 설정을 해도 새로고침 시 404 발생.
  -> 따라서,  로그인 없이 접근 가능한 /, /invite, /MonthView만 크롤링 및 SEO 대응하도록 설정을 조정
    - 로컬 정적/동적 build(npm run build, npm start)시 모두 잘 동작하는 거 확인했으나 배포 환경에서 테스트가 필요함.
     (hydratable 오피셜로 https 환경은 지원안한다고 하였음. 다만, 이전에 https환경에서 배포되었을 때도 랜딩페이지 등은 새로고침해도 404 미발생)

- 공유되는 링크 .site -> .com으로 변경

- MothView 페이지의 메뉴 버튼 임시 삭제