### PR TITLE
[UPDATE] 모든 시간 가능 버튼 임시 삭제

### DIFF
--- a/src/components/TimePicker.js
+++ b/src/components/TimePicker.js
@@ -9,8 +9,6 @@ const TimePicker = ({ startTime, endTime, setStartTime, setEndTime, onCreateCale
 
   // console.log('[TimePicker] isFormReady:', isFormReady);
 
-  const startMeridiemDialRef = useRef(null);
-  const startHourDialRef = useRef(null);
   const endMeridiemDialRef = useRef(null);
   const endHourDialRef = useRef(null);
 

--- a/src/pages/eventCalendar.js
+++ b/src/pages/eventCalendar.js
@@ -148,7 +148,7 @@ const KakaoShare = async() => {
             );
             const responseData = await appointmentResponse.json();
 
-            console.log("[TEST] responseData의 스케줄: ", responseData.object.schedules[0].times);
+            // console.log("[TEST] responseData의 스케줄: ", responseData.object.schedules[0].times);
             if (!responseData || !responseData.object) {
                 console.error('응답 데이터가 올바르지 않습니다');
                 return;


### PR DESCRIPTION
- 모든 시간 선택 버튼 클릭시 모든 시간을 묶어서 api요청 보내기 , 임의로 timeslot클릭하고 저장 버튼 클릭시 묶어서 시간대 보내기로 로직 분기
- 그러나, 연산 시간을 줄이고자 이렇게 분기처리한건데 여전히 한 엣지케이스에서 여전히 같은 문제가 발생함. 이걸 해결하고자 매번 로딩 처리하고자 했는데 그러면 UX 면에서 저하됨.
  - 따라서, 우선 모든 시간 가능 버튼을 빼고, 추후 순회 최적화 등을 적용키로 함.
  - 기타 안 쓰는 로직 삭제