### PR TITLE
[FIX]individualCalendar 스케줄 업데이트 add만 가능한  버그 fix

### DIFF
--- a/src/pages/eventCalendar.js
+++ b/src/pages/eventCalendar.js
@@ -148,7 +148,7 @@ const KakaoShare = async() => {
             );
             const responseData = await appointmentResponse.json();
 
-            console.log("[TEST] responseData의 스케줄: ", responseData.object.schedules[0].times);
+            // console.log("[TEST] responseData의 스케줄: ", responseData.object.schedules[0].times);
             if (!responseData || !responseData.object) {
                 console.error('응답 데이터가 올바르지 않습니다');
                 return;

--- a/src/pages/individualCalendar.js
+++ b/src/pages/individualCalendar.js
@@ -284,6 +284,7 @@ const debouncedUpdate = useCallback((timeIndex, buttonIndex, newValue) => {
           setSelectedTimes,
           selectedDate,
         );
+ 
       }
       // 드래그 상태 초기화
       dragStartRef.current = null;


### PR DESCRIPTION
- individualCalendar에서 첫 날짜에 대해 스케줄 추가만 가능하고 선택 해제가 불가 버그가 있었음.
   - 이전 commit에서 레거시 코드를 지우며 발생한 버그로 확인, 다시 되돌렸음
- eventCalenar의 불필요한 console.log 주석 처리